### PR TITLE
Remove pointless use of pclient.protocolVersion

### DIFF
--- a/src/packets.ts
+++ b/src/packets.ts
@@ -30,7 +30,7 @@ export function generatePackets(bot: Bot & { recipes: number[] }, pclient?: Clie
   if (!bot.entity) return [];
 
   //* load up some helper methods
-  const { toNotch: itemToNotch }: typeof import('prismarine-item').Item = require('prismarine-item')(pclient?.protocolVersion ?? bot.version);
+  const { toNotch: itemToNotch }: typeof import('prismarine-item').Item = require('prismarine-item')(bot.version);
   const Vec3: typeof import('vec3').default = require('vec3');
   const UUID = bot.player.uuid; //pclient?.uuid ??
 


### PR DESCRIPTION
Works with 2bored2wait and fixes random crashing on some machines.