### PR TITLE
Add packet un-canceling

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A function to interact with send packets between a connected client and the serv
 
 - Changing packets: Return the new packet data
 - Canceling the packet: Return `false`
+- Un-Cancel a packet that was canceled by a previous packet: Return `true`
 - Do nothing: Return `undefined`
 
 The returned value can also be wrapped in a promise. The middleware will await the promise result before continuing to process the packet.

--- a/src/conn.ts
+++ b/src/conn.ts
@@ -53,7 +53,7 @@ export interface PacketMiddleware {
   (packetData: PacketData): PacketMiddlewareReturnValue | Promise<PacketMiddlewareReturnValue>;
 }
 
-type PacketMiddlewareReturnValue = PacketData | undefined | false | true;
+type PacketMiddlewareReturnValue = PacketData | undefined | false | true | void;
 
 export class Conn {
   options: ConnOptions;

--- a/src/conn.ts
+++ b/src/conn.ts
@@ -376,14 +376,8 @@ export class Conn {
       } else {
         returnValue = funcReturn;
       }
-      if (!isCanceled) {
-        // Wait for the first occurrence
-        isCanceled = returnValue === false;
-      } else {
-        if (returnValue === true) {
-          isCanceled = false; // Allow following middlewares to un cancel packet that have been canceled already
-        }
-      }
+      // Cancel the packet if the return value is false. If the packet is already canceled it can be un canceled with true
+      isCanceled = isCanceled ? returnValue !== true : returnValue === false;
       if (returnValue !== undefined && returnValue !== false && returnValue !== true) {
         currentPacket = returnValue;
       }


### PR DESCRIPTION
When a packet has been canceled by a middleware following middleware may accidentally un cancel the packet by setting new data. This change makes un-canceling packet only possible when the middleware specifically returns `true`.